### PR TITLE
feat(semconv): rename pipeline db.operation.name as per semconv 1.32

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -194,7 +194,7 @@ func (ch *clientHook) ProcessHook(hook redis.ProcessHook) redis.ProcessHook {
 func (ch *clientHook) ProcessPipelineHook(hook redis.ProcessPipelineHook) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
 		summary, cmdsString := rediscmd.CmdsString(cmds)
-		oprName := "pipeline " + summary
+		oprName := "PIPELINE " + summary
 
 		attrs := make([]attribute.KeyValue, 0, 6)       //nolint:mnd // ignore
 		metricAttrs := make([]attribute.KeyValue, 0, 6) //nolint:mnd // ignore

--- a/hook_test.go
+++ b/hook_test.go
@@ -590,14 +590,14 @@ func Test_clientHook_ProcessPipelineHook(t *testing.T) {
 			},
 			checkSpan: func(t *testing.T, span sdktrace.ReadOnlySpan) {
 				t.Helper()
-				assert.Equal(t, "pipeline set get", span.Name())
+				assert.Equal(t, "PIPELINE set get", span.Name())
 				assert.Equal(t, sdktrace.Status{Code: codes.Unset}, span.Status())
 				t.Logf("attrs: %v", span.Attributes())
 
 				wantAttrs := []attribute.KeyValue{
 					semconv.DBSystemNameRedis,
 					semconv.DBNamespace("3"),
-					semconv.DBOperationName("pipeline set get"),
+					semconv.DBOperationName("PIPELINE set get"),
 					semconv.ServerAddress("10.1.1.1"),
 					semconv.ServerPort(6379),
 				}
@@ -616,7 +616,7 @@ func Test_clientHook_ProcessPipelineHook(t *testing.T) {
 				assertOprDuration(t, sm.Metrics[0], []attribute.KeyValue{
 					semconv.DBSystemNameRedis,
 					semconv.DBNamespace("3"),
-					semconv.DBOperationName("pipeline set get"),
+					semconv.DBOperationName("PIPELINE set get"),
 					semconv.DBOperationBatchSize(3),
 					semconv.ServerAddress("10.1.1.1"),
 					semconv.ServerPort(6379),
@@ -644,14 +644,14 @@ func Test_clientHook_ProcessPipelineHook(t *testing.T) {
 			},
 			checkSpan: func(t *testing.T, span sdktrace.ReadOnlySpan) {
 				t.Helper()
-				assert.Equal(t, "pipeline set get", span.Name())
+				assert.Equal(t, "PIPELINE set get", span.Name())
 				assert.Equal(t, sdktrace.Status{Code: codes.Unset}, span.Status())
 				t.Logf("attrs: %v", span.Attributes())
 
 				wantAttrs := []attribute.KeyValue{
 					semconv.DBSystemNameRedis,
 					semconv.DBNamespace("3"),
-					semconv.DBOperationName("pipeline set get"),
+					semconv.DBOperationName("PIPELINE set get"),
 					semconv.ServerAddress("10.1.1.1"),
 					semconv.ServerPort(6379),
 					semconv.DBQueryText("set key value\nget key1\nget key2"),
@@ -671,7 +671,7 @@ func Test_clientHook_ProcessPipelineHook(t *testing.T) {
 				assertOprDuration(t, sm.Metrics[0], []attribute.KeyValue{
 					semconv.DBSystemNameRedis,
 					semconv.DBNamespace("3"),
-					semconv.DBOperationName("pipeline set get"),
+					semconv.DBOperationName("PIPELINE set get"),
 					semconv.DBOperationBatchSize(3),
 					semconv.ServerAddress("10.1.1.1"),
 					semconv.ServerPort(6379),


### PR DESCRIPTION
https://github.com/open-telemetry/semantic-conventions/blob/v1.32.0/docs/database/redis.md